### PR TITLE
problem with SSL certificate on https://cssfx.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ In particular, applying gradients and background images to text is super underra
 
 - web components https://wc-spinners.cjennings.dev/
 - Spinners https://tobiasahlin.com/spinkit/
-- Buttons, hover, inputs, and loaders https://cssfx.dev
+- Buttons, hover, inputs, and loaders https://cssfx.netlify.com/
 - Conic gradient loader in CSS - [Codepen](https://codepen.io/keithclark/pen/aEbEoo)
 
 ### Animations & Transitions
 
-- Buttons, hover, inputs, and loaders https://cssfx.dev
+- Buttons, hover, inputs, and loaders https://cssfx.netlify.com/
 - general http://animista.net
   - animate an existing svg https://svgartista.net/ (by the same people as animista)
 - general https://daneden.github.io/animate.css/


### PR DESCRIPTION
Got this error while navigating to https://cssfx.dev:

  cssfx.dev normally uses encryption to protect your information. When Google Chrome tried to connect to cssfx.dev this time, the website 
  sent back unusual and incorrect credentials. This may happen when an attacker is trying to pretend to be cssfx.dev, or a Wi-Fi sign-in 
  screen has interrupted the connection. Your information is still secure because Google Chrome stopped the connection before any data 
  was exchanged.
  
  You cannot visit cssfx.dev right now because the website uses HSTS. Network errors and attacks are usually temporary, so this page will 
  probably work later.

I replaced url to use the new/working one: https://cssfx.netlify.com/