### PR TITLE
Add css-homogenizer to CSS Resets

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ more control in exchange for more work on your part.
   - https://gist.github.com/DavidWells/18e73022e723037a50d6
   - http://necolas.github.io/normalize.css/ (yes, technically does more than a reset)
     - Tailwind's https://tailwindcss.com/docs/preflight/ is built atop normalize
+  - https://github.com/kripod/css-homogenizer
 
 ### CSS A11y Checkers
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ more control in exchange for more work on your part.
   - https://gist.github.com/DavidWells/18e73022e723037a50d6
   - http://necolas.github.io/normalize.css/ (yes, technically does more than a reset)
     - Tailwind's https://tailwindcss.com/docs/preflight/ is built atop normalize
-  - https://github.com/kripod/css-homogenized - a modern take on Eric Meyer's Reset, based upon direct comparison between user agent style sheets.
+  - https://github.com/kripod/css-homogenizer - a modern take on Eric Meyer's Reset, based upon direct comparison between user agent style sheets.
 
 ### CSS A11y Checkers
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ more control in exchange for more work on your part.
   - https://gist.github.com/DavidWells/18e73022e723037a50d6
   - http://necolas.github.io/normalize.css/ (yes, technically does more than a reset)
     - Tailwind's https://tailwindcss.com/docs/preflight/ is built atop normalize
-  - https://github.com/kripod/css-homogenizer
+  - https://github.com/kripod/css-homogenized - a modern take on Eric Meyer's Reset, based upon direct comparison between user agent style sheets.
 
 ### CSS A11y Checkers
 


### PR DESCRIPTION
The [css-homogenizer](https://github.com/kripod/css-homogenizer) project is a modern take on [Eric Meyer's Reset](https://meyerweb.com/eric/tools/css/reset/), based upon direct comparison between user agent style sheets.