### PR TITLE
Removed LowPoly 3D

### DIFF
--- a/README.md
+++ b/README.md
@@ -1962,7 +1962,6 @@ Makepad
 
 ThreeJS
 
-- LowPoly 3D models from Google https://poly.google.com/search/duck
 - https://www.kukla-kit.com/ Huge pack of 3D elements accessible directly from Figma.
 
 BabylonJS


### PR DESCRIPTION
The service was shut down on June 30, 2021 by Google (https://support.google.com/poly/answer/10192635).